### PR TITLE
Fix frame removal error and CPU saturation

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,17 +1,26 @@
 {
   "manifest_version": 3,
   "name": "Page Digest",
-  "version": "1.1.0",
+  "version": "1.2.1",
   "description": "Extract article content and send to ChatGPT, Gemini, or Claude for summarization",
   "permissions": ["activeTab", "scripting", "storage"],
   "host_permissions": [
     "https://chatgpt.com/*",
     "https://gemini.google.com/*",
-    "https://claude.ai/*"
+    "https://claude.ai/*",
+    "https://*/*",
+    "http://*/*"
   ],
   "background": {
     "service_worker": "background.js"
   },
+  "content_scripts": [
+    {
+      "matches": ["https://*/*", "http://*/*"],
+      "js": ["dist/content.bundle.js"],
+      "run_at": "document_idle"
+    }
+  ],
   "action": {
     "default_icon": {
       "16": "icons/icon16.png",


### PR DESCRIPTION
## Summary
- Fix "Frame with ID 0 was removed" error on sites like Le Monde and The Verge
- Fix 100% CPU usage / infinite loop when triggering the extension
- Switch to more reliable message passing architecture

## Changes
- **manifest.json**: Add content_scripts for automatic injection, expand host_permissions
- **background.js**: Use `chrome.tabs.sendMessage` instead of `chrome.scripting.executeScript`
- **src/content.js**: Add message listener, fix infinite loop in `addSpacing()` by converting live NodeList to static array

## Root Causes
1. `chrome.scripting.executeScript` failed on sites with consent frameworks that manipulate the main frame
2. `addSpacing()` iterated over a live NodeList while modifying it via `insertAdjacentText()`

## Test plan
- [ ] Test on Le Monde article: https://www.lemonde.fr/international/
- [ ] Test on The Verge article: https://www.theverge.com/
- [ ] Verify no CPU spike when clicking extension
- [ ] Verify content is correctly extracted and sent to LLM

Fixes #1

🤖 Generated with [Claude Code](https://claude.ai/claude-code)